### PR TITLE
Enhance the code highlighting theme

### DIFF
--- a/content/assets/css/prism.css
+++ b/content/assets/css/prism.css
@@ -1,0 +1,141 @@
+/* PrismJS 1.29.0
+https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+abap+abnf+actionscript+ada+agda+al+antlr4+apacheconf+apl+applescript+aql+arduino+arff+asciidoc+aspnet+asm6502+autohotkey+autoit+bash+basic+batch+bbcode+birb+bison+bnf+brainfuck+brightscript+bro+bsl+c+csharp+cpp+cil+clojure+cmake+coffeescript+concurnas+csp+crystal+css-extras+cypher+d+dart+dax+dhall+diff+django+dns-zone-file+docker+ebnf+editorconfig+eiffel+ejs+elixir+elm+etlua+erb+erlang+excel-formula+fsharp+factor+firestore-security-rules+flow+fortran+ftl+gml+gcode+gdscript+gedcom+gherkin+git+glsl+go+graphql+groovy+haml+handlebars+haskell+haxe+hcl+hlsl+http+hpkp+hsts+ichigojam+icon+ignore+inform7+ini+io+j+java+javadoc+javadoclike+javastacktrace+jolie+jq+jsdoc+js-extras+json+json5+jsonp+jsstacktrace+js-templates+julia+keyman+kotlin+latex+latte+less+lilypond+liquid+lisp+livescript+llvm+lolcode+lua+makefile+markdown+markup-templating+matlab+mel+mizar+mongodb+monkey+moonscript+n1ql+n4js+nand2tetris-hdl+naniscript+nasm+neon+nginx+nim+nix+nsis+objectivec+ocaml+opencl+oz+parigp+parser+pascal+pascaligo+pcaxis+peoplecode+perl+php+phpdoc+php-extras+plsql+powerquery+powershell+processing+prolog+properties+protobuf+pug+puppet+pure+purebasic+purescript+python+q+qml+qore+r+racket+jsx+tsx+reason+regex+renpy+rest+rip+roboconf+robotframework+ruby+rust+sas+sass+scss+scala+scheme+shell-session+smali+smalltalk+smarty+sml+solidity+solution-file+soy+sparql+splunk-spl+sqf+sql+stan+iecst+stylus+swift+t4-templating+t4-cs+t4-vb+tap+tcl+tt2+textile+toml+turtle+twig+typescript+typoscript+unrealscript+vala+vbnet+velocity+verilog+vhdl+vim+visual-basic+warpscript+wasm+wiki+xeora+xml-doc+xojo+xquery+yaml+yang+zig&plugins=keep-markup */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+    color: black;
+    background: none;
+    text-shadow: 0 1px white;
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.5;
+
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+    text-shadow: none;
+    background: #b3d4fc;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+    text-shadow: none;
+    background: #b3d4fc;
+}
+
+@media print {
+    code[class*="language-"],
+    pre[class*="language-"] {
+        text-shadow: none;
+    }
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+    padding: 1em;
+    margin: .5em 0;
+    overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+    background: #f8f6f5;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+    padding: .1em;
+    border-radius: .3em;
+    white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: slategray;
+}
+
+.token.punctuation {
+    color: #999;
+}
+
+.token.namespace {
+    opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+    color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+    color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+    color: #9a6e3a;
+    /* This background color was intended by the author of this theme. */
+    background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+    color: #07a;
+}
+
+.token.function,
+.token.class-name {
+    color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+    color: #e90;
+}
+
+.token.important,
+.token.bold {
+    font-weight: bold;
+}
+.token.italic {
+    font-style: italic;
+}
+
+.token.entity {
+    cursor: help;
+}

--- a/content/assets/css/pygments-manni.css
+++ b/content/assets/css/pygments-manni.css
@@ -1,0 +1,238 @@
+td.linenos .normal {
+    color: inherit;
+    background-color: transparent;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+span.linenos {
+    color: inherit;
+    background-color: transparent;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+td.linenos .special {
+    color: #000000;
+    background-color: #ffffc0;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+span.linenos.special {
+    color: #000000;
+    background-color: #ffffc0;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+.hll {
+    background-color: #0969da4a;
+}
+.c {
+    color: #66707b;
+} /* Comment */
+.err {
+    color: #a0111f;
+} /* Error */
+.k {
+    color: #a0111f;
+} /* Keyword */
+.l {
+    color: #702c00;
+} /* Literal */
+.n {
+    color: #622cbc;
+} /* Name */
+.o {
+    color: #024c1a;
+} /* Operator */
+.p {
+    color: #24292f;
+} /* Punctuation */
+.ch {
+    color: #66707b;
+} /* Comment.Hashbang */
+.cm {
+    color: #66707b;
+} /* Comment.Multiline */
+.cp {
+    color: #66707b;
+} /* Comment.Preproc */
+.cpf {
+    color: #66707b;
+} /* Comment.PreprocFile */
+.c1 {
+    color: #66707b;
+} /* Comment.Single */
+.cs {
+    color: #66707b;
+} /* Comment.Special */
+.gd {
+    color: #023b95;
+} /* Generic.Deleted */
+.ge {
+    font-style: italic;
+} /* Generic.Emph */
+.gr {
+    color: #a0111f;
+} /* Generic.Error */
+.gh {
+    color: #023b95;
+} /* Generic.Heading */
+.gs {
+    font-weight: bold;
+} /* Generic.Strong */
+.gu {
+    color: #023b95;
+} /* Generic.Subheading */
+.kc {
+    color: #023b95;
+} /* Keyword.Constant */
+.kd {
+    color: #a0111f;
+} /* Keyword.Declaration */
+.kn {
+    color: #a0111f;
+} /* Keyword.Namespace */
+.kp {
+    color: #a0111f;
+} /* Keyword.Pseudo */
+.kr {
+    color: #a0111f;
+} /* Keyword.Reserved */
+.kt {
+    color: #a0111f;
+} /* Keyword.Type */
+.ld {
+    color: #702c00;
+} /* Literal.Date */
+.m {
+    color: #702c00;
+} /* Literal.Number */
+.s {
+    color: #023b95;
+} /* Literal.String */
+.na {
+    color: #702c00;
+} /* Name.Attribute */
+.nb {
+    color: #702c00;
+} /* Name.Builtin */
+.nc {
+    color: #023b95;
+} /* Name.Class */
+.no {
+    color: #023b95;
+} /* Name.Constant */
+.nd {
+    color: #702c00;
+} /* Name.Decorator */
+.ni {
+    color: #024c1a;
+} /* Name.Entity */
+.ne {
+    color: #622cbc;
+} /* Name.Exception */
+.nf {
+    color: #023b95;
+} /* Name.Function */
+.nl {
+    color: #702c00;
+} /* Name.Label */
+.nn {
+    color: #24292f;
+} /* Name.Namespace */
+.nx {
+    color: #622cbc;
+} /* Name.Other */
+.py {
+    color: #023b95;
+} /* Name.Property */
+.nt {
+    color: #024c1a;
+} /* Name.Tag */
+.nv {
+    color: #702c00;
+} /* Name.Variable */
+.ow {
+    color: #622cbc;
+} /* Operator.Word */
+.w {
+    color: #24292f;
+} /* Text.Whitespace */
+.mb {
+    color: #702c00;
+} /* Literal.Number.Bin */
+.mf {
+    color: #702c00;
+} /* Literal.Number.Float */
+.mh {
+    color: #702c00;
+} /* Literal.Number.Hex */
+.mi {
+    color: #702c00;
+} /* Literal.Number.Integer */
+.mo {
+    color: #702c00;
+} /* Literal.Number.Oct */
+.sa {
+    color: #023b95;
+} /* Literal.String.Affix */
+.sb {
+    color: #023b95;
+} /* Literal.String.Backtick */
+.sc {
+    color: #023b95;
+} /* Literal.String.Char */
+.dl {
+    color: #023b95;
+} /* Literal.String.Delimiter */
+.sd {
+    color: #023b95;
+} /* Literal.String.Doc */
+.s2 {
+    color: #023b95;
+} /* Literal.String.Double */
+.se {
+    color: #023b95;
+} /* Literal.String.Escape */
+.sh {
+    color: #023b95;
+} /* Literal.String.Heredoc */
+.si {
+    color: #023b95;
+} /* Literal.String.Interpol */
+.sx {
+    color: #023b95;
+} /* Literal.String.Other */
+.sr {
+    color: #023b95;
+} /* Literal.String.Regex */
+.s1 {
+    color: #023b95;
+} /* Literal.String.Single */
+.ss {
+    color: #023b95;
+} /* Literal.String.Symbol */
+.bp {
+    color: #702c00;
+} /* Name.Builtin.Pseudo */
+.fm {
+    color: #023b95;
+} /* Name.Function.Magic */
+.vc {
+    color: #702c00;
+} /* Name.Variable.Class */
+.vg {
+    color: #702c00;
+} /* Name.Variable.Global */
+.vi {
+    color: #702c00;
+} /* Name.Variable.Instance */
+.vm {
+    color: #702c00;
+} /* Name.Variable.Magic */
+.il {
+    color: #702c00;
+} /* Literal.Number.Integer.Long */
+.highlight {
+    background: #ffffff;
+    color: #24292f;
+}


### PR DESCRIPTION
This PR enhances the code highlighting theme. Some colours were difficult to read.

For Pygments, I took the [GitHub light high contrast](https://github.com/Quansight-Labs/accessible-pygments/tree/main/a11y_pygments/github_light_high_contrast), which targets WCAG AAA level.
For Prism, I only updated the theme, and lighten the background.

| Before | After | 
| ------------- | ------------- |
| ![2024-02-13 07 59 29  e6a743981413](https://github.com/hl7ch/ig-template/assets/3299399/0865d0bc-df69-409d-8a9a-0d72993a7618) | ![2024-02-13 08 15 15  ed5294615c0d](https://github.com/hl7ch/ig-template/assets/3299399/3832d0ef-f8f7-4910-9ca7-c41eb01a1e14) |